### PR TITLE
feature: 학교 정보 호출 api 구현

### DIFF
--- a/src/main/java/devping/nnplanner/domain/openapi/dto/response/SchoolInfoResponseDTO.java
+++ b/src/main/java/devping/nnplanner/domain/openapi/dto/response/SchoolInfoResponseDTO.java
@@ -1,0 +1,44 @@
+package devping.nnplanner.domain.openapi.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class SchoolInfoResponseDTO {
+
+    private List<SchoolData> schoolData;
+
+    @Getter
+    public class SchoolData {
+
+        private List<Head> head;
+        private List<SchoolRow> row;
+    }
+
+    @Getter
+    public class Head {
+
+        private Integer list_total_count;
+    }
+
+    @Getter
+    public class SchoolRow {
+
+        @JsonProperty("ATPT_OFCDC_SC_CODE")
+        private String schoolAreaCode;
+
+        @JsonProperty("ATPT_OFCDC_SC_NM")
+        private String schoolAreaName;
+
+        @JsonProperty("SD_SCHUL_CODE")
+        private String schoolCode;
+
+        @JsonProperty("SCHUL_NM")
+        private String schoolName;
+
+        @JsonProperty("SCHUL_KND_SC_NM")
+        private String schoolKindName;
+    }
+
+}

--- a/src/main/java/devping/nnplanner/domain/openapi/entity/SchoolInfo.java
+++ b/src/main/java/devping/nnplanner/domain/openapi/entity/SchoolInfo.java
@@ -4,12 +4,17 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.UuidGenerator;
 
 @Table(name = "school_infos")
+@Builder
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 @Entity
 public class SchoolInfo {
 
@@ -17,18 +22,25 @@ public class SchoolInfo {
     @UuidGenerator
     private UUID schoolInfoId;
 
-    @Setter
     private String schoolAreaCode;
 
-    @Setter
     private String schoolAreaName;
 
-    @Setter
     private String schoolCode;
 
-    @Setter
     private String schoolName;
 
-    @Setter
     private String schoolKindName;
+
+    public SchoolInfo create(String schoolAreaCode, String schoolAreaName, String schoolCode,
+                             String schoolName, String schoolKindName) {
+
+        return SchoolInfo.builder()
+                         .schoolAreaCode(schoolAreaCode)
+                         .schoolAreaName(schoolAreaName)
+                         .schoolCode(schoolCode)
+                         .schoolName(schoolName)
+                         .schoolKindName(schoolKindName)
+                         .build();
+    }
 }

--- a/src/main/java/devping/nnplanner/domain/openapi/entity/SchoolInfo.java
+++ b/src/main/java/devping/nnplanner/domain/openapi/entity/SchoolInfo.java
@@ -1,0 +1,34 @@
+package devping.nnplanner.domain.openapi.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.UuidGenerator;
+
+@Table(name = "school_infos")
+@Getter
+@Entity
+public class SchoolInfo {
+
+    @Id
+    @UuidGenerator
+    private UUID schoolInfoId;
+
+    @Setter
+    private String schoolAreaCode;
+
+    @Setter
+    private String schoolAreaName;
+
+    @Setter
+    private String schoolCode;
+
+    @Setter
+    private String schoolName;
+
+    @Setter
+    private String schoolKindName;
+}

--- a/src/main/java/devping/nnplanner/domain/openapi/repository/SchoolInfoRepository.java
+++ b/src/main/java/devping/nnplanner/domain/openapi/repository/SchoolInfoRepository.java
@@ -1,0 +1,9 @@
+package devping.nnplanner.domain.openapi.repository;
+
+import devping.nnplanner.domain.openapi.entity.SchoolInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SchoolInfoRepository extends JpaRepository<SchoolInfo, Long> {
+
+    boolean existsBySchoolCode(String schoolCode);
+}

--- a/src/main/java/devping/nnplanner/domain/openapi/service/SchoolInfoService.java
+++ b/src/main/java/devping/nnplanner/domain/openapi/service/SchoolInfoService.java
@@ -89,11 +89,14 @@ public class SchoolInfoService {
     private SchoolInfo convertToEntity(SchoolRow schoolRow) {
 
         SchoolInfo schoolInfo = new SchoolInfo();
-        schoolInfo.setSchoolAreaCode(schoolRow.getSchoolAreaCode());
-        schoolInfo.setSchoolAreaName(schoolRow.getSchoolAreaName());
-        schoolInfo.setSchoolCode(schoolRow.getSchoolCode());
-        schoolInfo.setSchoolName(schoolRow.getSchoolName());
-        schoolInfo.setSchoolKindName(schoolRow.getSchoolKindName());
+
+        schoolInfo.create(
+            schoolRow.getSchoolAreaCode(),
+            schoolRow.getSchoolAreaName(),
+            schoolRow.getSchoolCode(),
+            schoolRow.getSchoolName(),
+            schoolRow.getSchoolKindName());
+
         return schoolInfo;
     }
 }

--- a/src/main/java/devping/nnplanner/domain/openapi/service/SchoolInfoService.java
+++ b/src/main/java/devping/nnplanner/domain/openapi/service/SchoolInfoService.java
@@ -1,0 +1,99 @@
+package devping.nnplanner.domain.openapi.service;
+
+import devping.nnplanner.domain.openapi.dto.response.SchoolInfoResponseDTO;
+import devping.nnplanner.domain.openapi.dto.response.SchoolInfoResponseDTO.SchoolRow;
+import devping.nnplanner.domain.openapi.entity.SchoolInfo;
+import devping.nnplanner.domain.openapi.repository.SchoolInfoRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Service
+@RequiredArgsConstructor
+public class SchoolInfoService {
+
+    private final SchoolInfoRepository schoolInfoRepository;
+    private final WebClient webClient;
+
+    private Integer pageNo = 1;
+    private final Integer numOfRows = 100;
+    private int totalPages = Integer.MAX_VALUE;
+
+    @Value("${api.school.key}")
+    private String schoolApiKey;
+
+    @Autowired
+    public SchoolInfoService(
+        WebClient schoolWebClient,
+        SchoolInfoRepository schoolInfoRepository) {
+
+        this.webClient = schoolWebClient;
+        this.schoolInfoRepository = schoolInfoRepository;
+    }
+
+    public void getAllSchoolInfo() {
+
+        while (pageNo <= totalPages) {
+
+            SchoolInfoResponseDTO response =
+                webClient.get()
+                         .uri(uriBuilder -> uriBuilder
+                             .path("/schoolInfo")
+                             .queryParam("KEY", schoolApiKey)
+                             .queryParam("Type", "json")
+                             .queryParam("pIndex", pageNo)
+                             .queryParam("pSize", numOfRows)
+                             .build())
+                         .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                         .retrieve()
+                         .bodyToMono(SchoolInfoResponseDTO.class)
+                         .block();
+
+            if (response != null && response.getSchoolData() != null) {
+
+                List<SchoolRow> schoolRows =
+                    response.getSchoolData().stream()
+                            .flatMap(schoolData -> schoolData.getRow().stream())
+                            .collect(Collectors.toList());
+
+                saveSchoolInfo(schoolRows);
+
+                pageNo++;
+
+            } else {
+                break;
+            }
+        }
+    }
+
+    private void saveSchoolInfo(List<SchoolRow> schoolRows) {
+
+        List<SchoolInfo> schoolInfos =
+
+            schoolRows.stream()
+                      .filter(
+                          schoolRow ->
+                              !schoolInfoRepository.existsBySchoolCode(schoolRow.getSchoolCode()))
+                      .map(this::convertToEntity)
+                      .toList();
+
+        schoolInfoRepository.saveAll(schoolInfos);
+    }
+
+    private SchoolInfo convertToEntity(SchoolRow schoolRow) {
+
+        SchoolInfo schoolInfo = new SchoolInfo();
+        schoolInfo.setSchoolAreaCode(schoolRow.getSchoolAreaCode());
+        schoolInfo.setSchoolAreaName(schoolRow.getSchoolAreaName());
+        schoolInfo.setSchoolCode(schoolRow.getSchoolCode());
+        schoolInfo.setSchoolName(schoolRow.getSchoolName());
+        schoolInfo.setSchoolKindName(schoolRow.getSchoolKindName());
+        return schoolInfo;
+    }
+}

--- a/src/main/java/devping/nnplanner/global/config/WebClientConfig.java
+++ b/src/main/java/devping/nnplanner/global/config/WebClientConfig.java
@@ -29,7 +29,7 @@ public class WebClientConfig {
     }
 
     @Bean
-    public WebClient menuWebClient() {
+    public WebClient schoolWebClient() {
 
         ExchangeStrategies strategies =
             ExchangeStrategies.builder()
@@ -39,7 +39,7 @@ public class WebClientConfig {
 
         return WebClient.builder()
                         .baseUrl(
-                            "https://apis.data.go.kr/1471000/FoodNtrCpntDbInfo01/getFoodNtrCpntDbInq01")
+                            "https://open.neis.go.kr/hub")
                         .exchangeStrategies(strategies)
                         .build();
     }


### PR DESCRIPTION
### 주요 사항
1. webclient를 사용하여 학교 정보를 호출하는 api를 구현했습니다.
2. 응답값에서 시도교육청코드, 시도교육청명, 행정표준코드, 학교명, 학교종류명을 DB에 저장 되도록 구현했습니다.
3. 중복 체크를 통해 여러번 호출 하더라도 중복된 값은 저장이 안되도록 구현했습니다.

* 해당 api는 현재 교육청 서버 오류로 json 값이 응답으로 안오고있어서 테스트가 불가합니다. 
  교육청쪽에 문의 남겼으니 해결됐다는 답변이 오면 공유 드리겠습니다.