### PR TITLE
feature: 식단 자동 생성 api 구현

### DIFF
--- a/src/main/java/devping/nnplanner/NNplannerApplication.java
+++ b/src/main/java/devping/nnplanner/NNplannerApplication.java
@@ -1,12 +1,10 @@
 package devping.nnplanner;
 
-import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
-@EnableBatchProcessing
 @SpringBootApplication
 public class NNplannerApplication {
 

--- a/src/main/java/devping/nnplanner/domain/menu/entity/MonthMenu.java
+++ b/src/main/java/devping/nnplanner/domain/menu/entity/MonthMenu.java
@@ -1,5 +1,0 @@
-package devping.nnplanner.domain.menu.entity;
-
-public class MonthMenu {
-
-}

--- a/src/main/java/devping/nnplanner/domain/menucategory/entity/MenuCategory.java
+++ b/src/main/java/devping/nnplanner/domain/menucategory/entity/MenuCategory.java
@@ -1,5 +1,23 @@
 package devping.nnplanner.domain.menucategory.entity;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import java.util.UUID;
+import lombok.Getter;
+import org.hibernate.annotations.UuidGenerator;
+
+@Getter
+@Entity
 public class MenuCategory {
 
+    @Id
+    @UuidGenerator
+    private UUID menuCategoryId;
+
+    @Column(nullable = false)
+    private String majorCategory;
+
+    @Column(nullable = false)
+    private String minorCategory;
 }

--- a/src/main/java/devping/nnplanner/domain/monthmenu/controller/MonthMenuController.java
+++ b/src/main/java/devping/nnplanner/domain/monthmenu/controller/MonthMenuController.java
@@ -1,0 +1,34 @@
+package devping.nnplanner.domain.monthmenu.controller;
+
+import devping.nnplanner.domain.monthmenu.dto.request.MonthMenuAutoRequestDTO;
+import devping.nnplanner.domain.monthmenu.dto.response.MonthMenuAutoResponseDTO;
+import devping.nnplanner.domain.monthmenu.service.MonthMenuService;
+import devping.nnplanner.global.response.ApiResponse;
+import devping.nnplanner.global.response.GlobalResponse;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api/monthmenus")
+@RestController
+@RequiredArgsConstructor
+public class MonthMenuController {
+
+    private final MonthMenuService monthMenuService;
+
+    @PostMapping("/auto")
+    public ResponseEntity<ApiResponse<List<MonthMenuAutoResponseDTO>>> createMonthMenuAuto(
+        @RequestBody @Valid MonthMenuAutoRequestDTO monthMenuAutoRequestDTO) {
+
+        List<MonthMenuAutoResponseDTO> monthMenuAutoResponseDTO =
+            monthMenuService.createMonthMenuAuto(monthMenuAutoRequestDTO);
+
+        return GlobalResponse.CREATED("자동 식단 생성 성공", monthMenuAutoResponseDTO);
+    }
+
+}

--- a/src/main/java/devping/nnplanner/domain/monthmenu/dto/request/MonthMenuAutoRequestDTO.java
+++ b/src/main/java/devping/nnplanner/domain/monthmenu/dto/request/MonthMenuAutoRequestDTO.java
@@ -1,0 +1,18 @@
+package devping.nnplanner.domain.monthmenu.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class MonthMenuAutoRequestDTO {
+
+    @NotBlank
+    private String majorCategory;
+
+    @NotBlank
+    private String minorCategory;
+
+    @NotNull
+    private Integer dayCount;
+}

--- a/src/main/java/devping/nnplanner/domain/monthmenu/dto/response/FoodResponseDTO.java
+++ b/src/main/java/devping/nnplanner/domain/monthmenu/dto/response/FoodResponseDTO.java
@@ -1,0 +1,30 @@
+package devping.nnplanner.domain.monthmenu.dto.response;
+
+import devping.nnplanner.domain.openapi.entity.Food;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class FoodResponseDTO {
+
+    private final UUID foodId;
+
+    private final String foodName;
+
+    private final String carbohydrate;
+
+    private final String protein;
+
+    private final String fat;
+
+    private final String kcal;
+
+    public FoodResponseDTO(Food food) {
+        this.foodId = food.getFoodId();
+        this.foodName = food.getFoodName();
+        this.carbohydrate = food.getCarbohydrate();
+        this.protein = food.getProtein();
+        this.fat = food.getFat();
+        this.kcal = food.getKcal();
+    }
+}

--- a/src/main/java/devping/nnplanner/domain/monthmenu/dto/response/MonthMenuAutoResponseDTO.java
+++ b/src/main/java/devping/nnplanner/domain/monthmenu/dto/response/MonthMenuAutoResponseDTO.java
@@ -1,0 +1,33 @@
+package devping.nnplanner.domain.monthmenu.dto.response;
+
+import devping.nnplanner.domain.openapi.entity.HospitalMenu;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class MonthMenuAutoResponseDTO {
+
+    private final UUID hospitalMenuId;
+
+    private final String hospitalMenuKind;
+
+    private final List<FoodResponseDTO> foods;
+
+    public MonthMenuAutoResponseDTO(HospitalMenu hospitalMenu) {
+
+        this.hospitalMenuId = hospitalMenu.getHospitalMenuId();
+        this.hospitalMenuKind = hospitalMenu.getHospitalMenuKind();
+        this.foods = new ArrayList<>(Arrays.asList(
+            new FoodResponseDTO(hospitalMenu.getFood1()),
+            new FoodResponseDTO(hospitalMenu.getFood2()),
+            new FoodResponseDTO(hospitalMenu.getFood3()),
+            new FoodResponseDTO(hospitalMenu.getFood4()),
+            new FoodResponseDTO(hospitalMenu.getFood5()),
+            new FoodResponseDTO(hospitalMenu.getFood6()),
+            new FoodResponseDTO(hospitalMenu.getFood7())
+        ));
+    }
+}

--- a/src/main/java/devping/nnplanner/domain/monthmenu/entity/MonthMenu.java
+++ b/src/main/java/devping/nnplanner/domain/monthmenu/entity/MonthMenu.java
@@ -1,0 +1,50 @@
+package devping.nnplanner.domain.monthmenu.entity;
+
+import devping.nnplanner.domain.auth.entity.User;
+import devping.nnplanner.domain.menucategory.entity.MenuCategory;
+import devping.nnplanner.global.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UuidGenerator;
+
+@Table(name = "month_menus")
+@Getter
+@NoArgsConstructor
+@Entity
+public class MonthMenu extends BaseTimeEntity {
+
+    @Id
+    @UuidGenerator
+    private UUID monthMenuId;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "menu_category_id", nullable = false)
+    private MenuCategory menuCategory;
+
+    @Column(nullable = false)
+    private String monthMenuName;
+
+    @Column(nullable = false)
+    private String month;
+
+    public void create(User user,
+                       MenuCategory menuCategory,
+                       String monthMenuName,
+                       String month) {
+        this.user = user;
+        this.menuCategory = menuCategory;
+        this.monthMenuName = monthMenuName;
+        this.month = month;
+    }
+}

--- a/src/main/java/devping/nnplanner/domain/monthmenu/entity/MonthMenuHospital.java
+++ b/src/main/java/devping/nnplanner/domain/monthmenu/entity/MonthMenuHospital.java
@@ -1,0 +1,29 @@
+package devping.nnplanner.domain.monthmenu.entity;
+
+import devping.nnplanner.domain.openapi.entity.HospitalMenu;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+
+@Table(name = "month_menu_hospitals")
+@Getter
+@Entity
+public class MonthMenuHospital {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long monthMenuHospitalId;
+
+    @ManyToOne
+    @JoinColumn(name = "month_menu_id", nullable = false)
+    private MonthMenu monthMenu;
+
+    @ManyToOne
+    @JoinColumn(name = "hospital_menu_id", nullable = false)
+    private HospitalMenu hospitalMenu;
+}

--- a/src/main/java/devping/nnplanner/domain/monthmenu/repository/MonthMenuRepository.java
+++ b/src/main/java/devping/nnplanner/domain/monthmenu/repository/MonthMenuRepository.java
@@ -1,0 +1,8 @@
+package devping.nnplanner.domain.monthmenu.repository;
+
+import devping.nnplanner.domain.monthmenu.entity.MonthMenu;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MonthMenuRepository extends JpaRepository<MonthMenu, Long> {
+
+}

--- a/src/main/java/devping/nnplanner/domain/monthmenu/service/MonthMenuService.java
+++ b/src/main/java/devping/nnplanner/domain/monthmenu/service/MonthMenuService.java
@@ -1,0 +1,37 @@
+package devping.nnplanner.domain.monthmenu.service;
+
+import devping.nnplanner.domain.monthmenu.dto.request.MonthMenuAutoRequestDTO;
+import devping.nnplanner.domain.monthmenu.dto.response.MonthMenuAutoResponseDTO;
+import devping.nnplanner.domain.monthmenu.repository.MonthMenuRepository;
+import devping.nnplanner.domain.openapi.entity.HospitalMenu;
+import devping.nnplanner.domain.openapi.repository.HospitalMenuRepository;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MonthMenuService {
+
+    private final MonthMenuRepository monthMenuRepository;
+    private final HospitalMenuRepository hospitalMenuRepository;
+
+    public List<MonthMenuAutoResponseDTO> createMonthMenuAuto(
+        MonthMenuAutoRequestDTO requestDTO) {
+
+        if (requestDTO.getMajorCategory().equals("병원")) {
+
+            List<HospitalMenu> randomHospitalMenus =
+                hospitalMenuRepository.findRandomHospitalMenusByCategory(
+                    requestDTO.getMinorCategory(), requestDTO.getDayCount());
+
+            return randomHospitalMenus.stream()
+                                      .map(MonthMenuAutoResponseDTO::new)
+                                      .collect(Collectors.toList());
+        }
+
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/devping/nnplanner/domain/openapi/entity/HospitalMenu.java
+++ b/src/main/java/devping/nnplanner/domain/openapi/entity/HospitalMenu.java
@@ -1,5 +1,6 @@
 package devping.nnplanner.domain.openapi.entity;
 
+import devping.nnplanner.global.entity.BaseTimeEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
@@ -18,11 +19,11 @@ import org.hibernate.annotations.UuidGenerator;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class HospitalMenu {
+public class HospitalMenu extends BaseTimeEntity {
 
     @Id
     @UuidGenerator
-    private UUID hospitalDMId;
+    private UUID hospitalMenuId;
 
     private String hospitalMenuKind;
 

--- a/src/main/java/devping/nnplanner/domain/openapi/entity/ImportHospitalMenu.java
+++ b/src/main/java/devping/nnplanner/domain/openapi/entity/ImportHospitalMenu.java
@@ -14,7 +14,7 @@ public class ImportHospitalMenu {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long hospitalMenuId;
+    private Long importHospitalMenuId;
 
     private String menuKind;
 

--- a/src/main/java/devping/nnplanner/domain/openapi/repository/HospitalMenuRepository.java
+++ b/src/main/java/devping/nnplanner/domain/openapi/repository/HospitalMenuRepository.java
@@ -5,7 +5,8 @@ import devping.nnplanner.domain.openapi.entity.HospitalMenu;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface HospitalMenuRepository extends JpaRepository<HospitalMenu, UUID> {
+public interface HospitalMenuRepository extends JpaRepository<HospitalMenu, UUID>,
+    HospitalMenuRepositoryCustom {
 
     boolean existsByHospitalMenuKindAndFood1AndFood2AndFood3AndFood4AndFood5AndFood6AndFood7(
         String hospitalMenuKind,

--- a/src/main/java/devping/nnplanner/domain/openapi/repository/HospitalMenuRepositoryCustom.java
+++ b/src/main/java/devping/nnplanner/domain/openapi/repository/HospitalMenuRepositoryCustom.java
@@ -1,0 +1,9 @@
+package devping.nnplanner.domain.openapi.repository;
+
+import devping.nnplanner.domain.openapi.entity.HospitalMenu;
+import java.util.List;
+
+public interface HospitalMenuRepositoryCustom {
+
+    List<HospitalMenu> findRandomHospitalMenusByCategory(String hospitalMenuKind, int dayCount);
+}

--- a/src/main/java/devping/nnplanner/domain/openapi/repository/HospitalMenuRepositoryCustomImpl.java
+++ b/src/main/java/devping/nnplanner/domain/openapi/repository/HospitalMenuRepositoryCustomImpl.java
@@ -1,0 +1,28 @@
+package devping.nnplanner.domain.openapi.repository;
+
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import devping.nnplanner.domain.openapi.entity.HospitalMenu;
+import devping.nnplanner.domain.openapi.entity.QHospitalMenu;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class HospitalMenuRepositoryCustomImpl implements HospitalMenuRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<HospitalMenu> findRandomHospitalMenusByCategory(String hospitalMenuKind,
+                                                                int dayCount) {
+
+        QHospitalMenu hospitalMenu = QHospitalMenu.hospitalMenu;
+
+        return queryFactory
+            .selectFrom(hospitalMenu)
+            .where(hospitalMenu.hospitalMenuKind.eq(hospitalMenuKind))
+            .orderBy(Expressions.numberTemplate(Double.class, "function('random')").asc())
+            .limit(dayCount)
+            .fetch();
+    }
+}

--- a/src/main/java/devping/nnplanner/global/config/QuerydslConfig.java
+++ b/src/main/java/devping/nnplanner/global/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package devping.nnplanner.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@RequiredArgsConstructor
+@Configuration
+public class QuerydslConfig {
+
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}


### PR DESCRIPTION
### 주요사항
1. request로 받아오는 dayCount 만큼 랜덤한 식단 정보를 response 하도록 구현했습니다.
2. request로 받아오는 category 를 기준으로 랜덤한 식단 정보를 response 하도록 구현했습니다.
3. 추후 식단 저장 api 구현을 위하 월별식단-병원식단 중간테이블을 구현했습니다.
4. JPQL 로 작성하기 어려운 조회를 Querydsl 사용하여 조회 했습니다.