### PR TITLE
feature: 월별 식단 저장 api 구현

### DIFF
--- a/src/main/java/devping/nnplanner/domain/auth/dto/response/AuthResponseDTO.java
+++ b/src/main/java/devping/nnplanner/domain/auth/dto/response/AuthResponseDTO.java
@@ -6,15 +6,15 @@ import lombok.Getter;
 @Getter
 public class AuthResponseDTO {
 
-    private Long userId;
+    private final Long userId;
 
-    private String username;
+    private final String username;
 
-    private String email;
+    private final String email;
 
-    private String accessToken;
+    private final String accessToken;
 
-    private String refreshToken;
+    private final String refreshToken;
 
     public AuthResponseDTO(User user, String accessToken, String refreshToken) {
         this.userId = user.getUserId();

--- a/src/main/java/devping/nnplanner/domain/auth/dto/response/AuthTokenResponseDTO.java
+++ b/src/main/java/devping/nnplanner/domain/auth/dto/response/AuthTokenResponseDTO.java
@@ -5,9 +5,9 @@ import lombok.Getter;
 @Getter
 public class AuthTokenResponseDTO {
 
-    private String accessToken;
+    private final String accessToken;
 
-    private String refreshToken;
+    private final String refreshToken;
 
     public AuthTokenResponseDTO(String accessToken, String refreshToken) {
         this.accessToken = accessToken;

--- a/src/main/java/devping/nnplanner/domain/menucategory/repository/MenuCategoryRepository.java
+++ b/src/main/java/devping/nnplanner/domain/menucategory/repository/MenuCategoryRepository.java
@@ -1,0 +1,11 @@
+package devping.nnplanner.domain.menucategory.repository;
+
+import devping.nnplanner.domain.menucategory.entity.MenuCategory;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MenuCategoryRepository extends JpaRepository<MenuCategory, Long> {
+
+    Optional<MenuCategory> findByMajorCategoryAndMinorCategory(String majorCategory,
+                                                               String minorCategory);
+}

--- a/src/main/java/devping/nnplanner/domain/monthmenu/controller/MonthMenuController.java
+++ b/src/main/java/devping/nnplanner/domain/monthmenu/controller/MonthMenuController.java
@@ -1,14 +1,17 @@
 package devping.nnplanner.domain.monthmenu.controller;
 
 import devping.nnplanner.domain.monthmenu.dto.request.MonthMenuAutoRequestDTO;
+import devping.nnplanner.domain.monthmenu.dto.request.MonthMenuSaveRequestDTO;
 import devping.nnplanner.domain.monthmenu.dto.response.MonthMenuAutoResponseDTO;
 import devping.nnplanner.domain.monthmenu.service.MonthMenuService;
+import devping.nnplanner.global.jwt.user.UserDetailsImpl;
 import devping.nnplanner.global.response.ApiResponse;
 import devping.nnplanner.global.response.GlobalResponse;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,6 +32,16 @@ public class MonthMenuController {
             monthMenuService.createMonthMenuAuto(monthMenuAutoRequestDTO);
 
         return GlobalResponse.CREATED("자동 식단 생성 성공", monthMenuAutoResponseDTO);
+    }
+
+    @PostMapping("/save")
+    public ResponseEntity<ApiResponse<Void>> saveMonthMenuAuto(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @RequestBody @Valid MonthMenuSaveRequestDTO monthMenuSaveRequestDTO) {
+
+        monthMenuService.saveMonthMenu(userDetails, monthMenuSaveRequestDTO);
+
+        return GlobalResponse.OK("월별 식단 저장 성공", null);
     }
 
 }

--- a/src/main/java/devping/nnplanner/domain/monthmenu/dto/request/MonthMenuSaveRequestDTO.java
+++ b/src/main/java/devping/nnplanner/domain/monthmenu/dto/request/MonthMenuSaveRequestDTO.java
@@ -1,0 +1,52 @@
+package devping.nnplanner.domain.monthmenu.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class MonthMenuSaveRequestDTO {
+
+    @NotBlank
+    private String monthMenuName;
+
+    @NotBlank
+    private String majorCategory;
+
+    @NotBlank
+    private String minorCategory;
+
+    private List<MonthMenusSave> monthMenusSaveList;
+
+    @Getter
+    public static class MonthMenusSave {
+
+        private String hospitalMenuId;
+
+        @NotNull
+        private LocalDate menuDate;
+
+        @NotBlank
+        private String food1;
+
+        @NotBlank
+        private String food2;
+
+        @NotBlank
+        private String food3;
+
+        @NotBlank
+        private String food4;
+
+        @NotBlank
+        private String food5;
+
+        @NotBlank
+        private String food6;
+
+        @NotBlank
+        private String food7;
+    }
+}

--- a/src/main/java/devping/nnplanner/domain/monthmenu/entity/MonthMenu.java
+++ b/src/main/java/devping/nnplanner/domain/monthmenu/entity/MonthMenu.java
@@ -35,16 +35,11 @@ public class MonthMenu extends BaseTimeEntity {
     @Column(nullable = false)
     private String monthMenuName;
 
-    @Column(nullable = false)
-    private String month;
-
     public void create(User user,
                        MenuCategory menuCategory,
-                       String monthMenuName,
-                       String month) {
+                       String monthMenuName) {
         this.user = user;
         this.menuCategory = menuCategory;
         this.monthMenuName = monthMenuName;
-        this.month = month;
     }
 }

--- a/src/main/java/devping/nnplanner/domain/monthmenu/entity/MonthMenuHospital.java
+++ b/src/main/java/devping/nnplanner/domain/monthmenu/entity/MonthMenuHospital.java
@@ -1,14 +1,16 @@
 package devping.nnplanner.domain.monthmenu.entity;
 
 import devping.nnplanner.domain.openapi.entity.HospitalMenu;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.util.UUID;
 import lombok.Getter;
+import org.hibernate.annotations.UuidGenerator;
 
 @Table(name = "month_menu_hospitals")
 @Getter
@@ -16,8 +18,11 @@ import lombok.Getter;
 public class MonthMenuHospital {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long monthMenuHospitalId;
+    @UuidGenerator
+    private UUID monthMenuHospitalId;
+
+    @Column(nullable = false)
+    private LocalDate menuDate;
 
     @ManyToOne
     @JoinColumn(name = "month_menu_id", nullable = false)
@@ -26,4 +31,12 @@ public class MonthMenuHospital {
     @ManyToOne
     @JoinColumn(name = "hospital_menu_id", nullable = false)
     private HospitalMenu hospitalMenu;
+
+    public void create(LocalDate menuDate,
+                       MonthMenu monthMenu,
+                       HospitalMenu hospitalMenu) {
+        this.menuDate = menuDate;
+        this.monthMenu = monthMenu;
+        this.hospitalMenu = hospitalMenu;
+    }
 }

--- a/src/main/java/devping/nnplanner/domain/monthmenu/repository/MonthMenuHospitalRepository.java
+++ b/src/main/java/devping/nnplanner/domain/monthmenu/repository/MonthMenuHospitalRepository.java
@@ -1,0 +1,8 @@
+package devping.nnplanner.domain.monthmenu.repository;
+
+import devping.nnplanner.domain.monthmenu.entity.MonthMenuHospital;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MonthMenuHospitalRepository extends JpaRepository<MonthMenuHospital, Long> {
+
+}

--- a/src/main/java/devping/nnplanner/domain/monthmenu/service/MonthMenuService.java
+++ b/src/main/java/devping/nnplanner/domain/monthmenu/service/MonthMenuService.java
@@ -1,12 +1,24 @@
 package devping.nnplanner.domain.monthmenu.service;
 
+import devping.nnplanner.domain.menucategory.entity.MenuCategory;
+import devping.nnplanner.domain.menucategory.repository.MenuCategoryRepository;
 import devping.nnplanner.domain.monthmenu.dto.request.MonthMenuAutoRequestDTO;
+import devping.nnplanner.domain.monthmenu.dto.request.MonthMenuSaveRequestDTO;
 import devping.nnplanner.domain.monthmenu.dto.response.MonthMenuAutoResponseDTO;
+import devping.nnplanner.domain.monthmenu.entity.MonthMenu;
+import devping.nnplanner.domain.monthmenu.entity.MonthMenuHospital;
+import devping.nnplanner.domain.monthmenu.repository.MonthMenuHospitalRepository;
 import devping.nnplanner.domain.monthmenu.repository.MonthMenuRepository;
+import devping.nnplanner.domain.openapi.entity.Food;
 import devping.nnplanner.domain.openapi.entity.HospitalMenu;
+import devping.nnplanner.domain.openapi.repository.FoodRepository;
 import devping.nnplanner.domain.openapi.repository.HospitalMenuRepository;
+import devping.nnplanner.global.exception.CustomException;
+import devping.nnplanner.global.exception.ErrorCode;
+import devping.nnplanner.global.jwt.user.UserDetailsImpl;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,8 +27,11 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class MonthMenuService {
 
+    private final FoodRepository foodRepository;
     private final MonthMenuRepository monthMenuRepository;
     private final HospitalMenuRepository hospitalMenuRepository;
+    private final MenuCategoryRepository menuCategoryRepository;
+    private final MonthMenuHospitalRepository monthMenuHospitalRepository;
 
     public List<MonthMenuAutoResponseDTO> createMonthMenuAuto(
         MonthMenuAutoRequestDTO requestDTO) {
@@ -34,4 +49,70 @@ public class MonthMenuService {
 
         return Collections.emptyList();
     }
+
+    public void saveMonthMenu(UserDetailsImpl userDetails, MonthMenuSaveRequestDTO requestDTO) {
+
+        MenuCategory menuCategory =
+            menuCategoryRepository.findByMajorCategoryAndMinorCategory(
+                                      requestDTO.getMajorCategory(),
+                                      requestDTO.getMinorCategory())
+                                  .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+
+        MonthMenu monthMenu = new MonthMenu();
+        monthMenu.create(userDetails.getUser(), menuCategory, requestDTO.getMonthMenuName());
+        monthMenuRepository.save(monthMenu);
+
+        if (requestDTO.getMajorCategory().equals("병원")) {
+            requestDTO.getMonthMenusSaveList().forEach(menuSaveDTO -> {
+                if (menuSaveDTO.getHospitalMenuId() != null) {
+
+                    HospitalMenu hospitalMenu =
+                        hospitalMenuRepository
+                            .findById(UUID.fromString(menuSaveDTO.getHospitalMenuId()))
+                            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+
+                    MonthMenuHospital monthMenuHospital = new MonthMenuHospital();
+                    monthMenuHospital.create(menuSaveDTO.getMenuDate(), monthMenu, hospitalMenu);
+                    monthMenuHospitalRepository.save(monthMenuHospital);
+
+                } else {
+
+                    Food food1 = foodRepository.findById(UUID.fromString(menuSaveDTO.getFood1()))
+                                               .orElse(null);
+                    Food food2 = foodRepository.findById(UUID.fromString(menuSaveDTO.getFood2()))
+                                               .orElse(null);
+                    Food food3 = foodRepository.findById(UUID.fromString(menuSaveDTO.getFood3()))
+                                               .orElse(null);
+                    Food food4 = foodRepository.findById(UUID.fromString(menuSaveDTO.getFood4()))
+                                               .orElse(null);
+                    Food food5 = foodRepository.findById(UUID.fromString(menuSaveDTO.getFood5()))
+                                               .orElse(null);
+                    Food food6 = foodRepository.findById(UUID.fromString(menuSaveDTO.getFood6()))
+                                               .orElse(null);
+                    Food food7 = foodRepository.findById(UUID.fromString(menuSaveDTO.getFood7()))
+                                               .orElse(null);
+
+                    HospitalMenu hospitalMenu = HospitalMenu.builder()
+                                                            .hospitalMenuKind(
+                                                                requestDTO.getMinorCategory())
+                                                            .food1(food1)
+                                                            .food2(food2)
+                                                            .food3(food3)
+                                                            .food4(food4)
+                                                            .food5(food5)
+                                                            .food6(food6)
+                                                            .food7(food7)
+                                                            .build();
+
+                    hospitalMenuRepository.save(hospitalMenu);
+
+                    MonthMenuHospital monthMenuHospital = new MonthMenuHospital();
+                    monthMenuHospital.create(menuSaveDTO.getMenuDate(), monthMenu, hospitalMenu);
+                    monthMenuHospitalRepository.save(monthMenuHospital);
+                }
+            });
+        }
+    }
 }
+
+

--- a/src/main/java/devping/nnplanner/domain/openapi/repository/HospitalMenuRepositoryCustomImpl.java
+++ b/src/main/java/devping/nnplanner/domain/openapi/repository/HospitalMenuRepositoryCustomImpl.java
@@ -20,8 +20,10 @@ public class HospitalMenuRepositoryCustomImpl implements HospitalMenuRepositoryC
 
         return queryFactory
             .selectFrom(hospitalMenu)
-            .where(hospitalMenu.hospitalMenuKind.eq(hospitalMenuKind))
-            .orderBy(Expressions.numberTemplate(Double.class, "function('random')").asc())
+            .where(
+                hospitalMenu.hospitalMenuKind.eq(hospitalMenuKind)
+                                             .and(hospitalMenu.createdBy.isNull())
+            ).orderBy(Expressions.numberTemplate(Double.class, "function('random')").asc())
             .limit(dayCount)
             .fetch();
     }


### PR DESCRIPTION
### 주요 사항
1. 자동으로 생성된 식단 또는 수동으로 생성한 식단을 저장 할 수 있는 api를 구현했습니다.
2. 수정된 식단의 경우 hospitalMenuId null로 요청해야 식단 저장이 가능합니다.
3. menuCategory DB에 데이터가 있어야 저장이 가능하기 때문에 아래 쿼리문으로 import 후 테스트 부탁드립니다.
`INSERT INTO menu_category (menu_category_id, major_category, minor_category)
VALUES ('3ecf335d-0a63-4d51-a4f4-3f5f0932c0f9', '병원', '일반상식');`