### PR TITLE
feaure: 소분류 카테고리 목록 조회 api 구현 / 작성한 식단 카테고리별 조회 api 구현

### DIFF
--- a/src/main/java/devping/nnplanner/domain/menucategory/controller/MenuCategoryController.java
+++ b/src/main/java/devping/nnplanner/domain/menucategory/controller/MenuCategoryController.java
@@ -1,11 +1,17 @@
 package devping.nnplanner.domain.menucategory.controller;
 
 import devping.nnplanner.domain.menucategory.service.MenuCategoryService;
+import devping.nnplanner.domain.monthmenu.dto.response.MonthMenuPageResponseDTO;
+import devping.nnplanner.global.jwt.user.UserDetailsImpl;
 import devping.nnplanner.global.response.ApiResponse;
 import devping.nnplanner.global.response.GlobalResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -26,4 +32,23 @@ public class MenuCategoryController {
 
         return GlobalResponse.OK("소분류 목록 조회 성공", menuCategory);
     }
+
+    @GetMapping("/month-menus")
+    public ResponseEntity<ApiResponse<MonthMenuPageResponseDTO>> getAllMonthMenuByCategoryId(
+        @RequestParam("major-category") String majorCategory,
+        @RequestParam("minor-category") String minorCategory,
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @PageableDefault(page = 0, size = 8, sort = "createdAt",
+            direction = Sort.Direction.DESC) Pageable pageable) {
+
+        MonthMenuPageResponseDTO monthMenuPageResponseDTO =
+            menuCategoryService.getAllMonthMenuByCategoryId(
+                userDetails,
+                majorCategory,
+                minorCategory,
+                pageable);
+
+        return GlobalResponse.OK("작성한 식단 카테고리별 전체 조회 성공", monthMenuPageResponseDTO);
+    }
 }
+

--- a/src/main/java/devping/nnplanner/domain/menucategory/controller/MenuCategoryController.java
+++ b/src/main/java/devping/nnplanner/domain/menucategory/controller/MenuCategoryController.java
@@ -1,0 +1,29 @@
+package devping.nnplanner.domain.menucategory.controller;
+
+import devping.nnplanner.domain.menucategory.service.MenuCategoryService;
+import devping.nnplanner.global.response.ApiResponse;
+import devping.nnplanner.global.response.GlobalResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/menu-categories")
+public class MenuCategoryController {
+
+    private final MenuCategoryService menuCategoryService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<String>>> getMenuCategory(
+        @RequestParam("major-category") String majorCategory) {
+
+        List<String> menuCategory = menuCategoryService.getMenuCategory(majorCategory);
+
+        return GlobalResponse.OK("소분류 목록 조회 성공", menuCategory);
+    }
+}

--- a/src/main/java/devping/nnplanner/domain/menucategory/controller/MenuCategoryController.java
+++ b/src/main/java/devping/nnplanner/domain/menucategory/controller/MenuCategoryController.java
@@ -51,4 +51,3 @@ public class MenuCategoryController {
         return GlobalResponse.OK("작성한 식단 카테고리별 전체 조회 성공", monthMenuPageResponseDTO);
     }
 }
-

--- a/src/main/java/devping/nnplanner/domain/menucategory/service/MenuCategoryService.java
+++ b/src/main/java/devping/nnplanner/domain/menucategory/service/MenuCategoryService.java
@@ -1,10 +1,19 @@
 package devping.nnplanner.domain.menucategory.service;
 
+import devping.nnplanner.domain.menucategory.entity.MenuCategory;
 import devping.nnplanner.domain.menucategory.repository.MenuCategoryRepository;
+import devping.nnplanner.domain.monthmenu.dto.response.MonthMenuPageResponseDTO;
+import devping.nnplanner.domain.monthmenu.dto.response.MonthMenuResponseDTO;
+import devping.nnplanner.domain.monthmenu.entity.MonthMenu;
 import devping.nnplanner.domain.monthmenu.repository.MonthMenuRepository;
 import devping.nnplanner.domain.openapi.repository.HospitalMenuRepository;
+import devping.nnplanner.global.exception.CustomException;
+import devping.nnplanner.global.exception.ErrorCode;
+import devping.nnplanner.global.jwt.user.UserDetailsImpl;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -25,5 +34,32 @@ public class MenuCategoryService {
         } else {
             return null; //TODO: 학교,학교명인경우 추가
         }
+    }
+
+    public MonthMenuPageResponseDTO getAllMonthMenuByCategoryId(UserDetailsImpl userDetails,
+                                                                String majorCategory,
+                                                                String minorCategory,
+                                                                Pageable pageable) {
+
+        MenuCategory menuCategory =
+            menuCategoryRepository.findByMajorCategoryAndMinorCategory(majorCategory, minorCategory)
+                                  .orElseThrow(() -> new CustomException((ErrorCode.NOT_FOUND)));
+
+        Page<MonthMenu> monthMenuPage =
+            monthMenuRepository.findAllByUser_UserIdAndMenuCategory(
+                userDetails.getUser().getUserId(), menuCategory, pageable);
+
+        List<MonthMenuResponseDTO> menuResponseDTOS =
+            monthMenuPage.stream()
+                         .map(page -> new MonthMenuResponseDTO(page, null))
+                         .toList();
+
+        return new MonthMenuPageResponseDTO(
+            monthMenuPage.getNumber(),
+            monthMenuPage.getTotalPages(),
+            monthMenuPage.getTotalElements(),
+            monthMenuPage.getSize(),
+            menuResponseDTOS
+        );
     }
 }

--- a/src/main/java/devping/nnplanner/domain/menucategory/service/MenuCategoryService.java
+++ b/src/main/java/devping/nnplanner/domain/menucategory/service/MenuCategoryService.java
@@ -1,0 +1,29 @@
+package devping.nnplanner.domain.menucategory.service;
+
+import devping.nnplanner.domain.menucategory.repository.MenuCategoryRepository;
+import devping.nnplanner.domain.monthmenu.repository.MonthMenuRepository;
+import devping.nnplanner.domain.openapi.repository.HospitalMenuRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class MenuCategoryService {
+
+    private final MenuCategoryRepository menuCategoryRepository;
+    private final HospitalMenuRepository hospitalMenuRepository;
+    private final MonthMenuRepository monthMenuRepository;
+
+    public List<String> getMenuCategory(String majorCategory) {
+
+        if (majorCategory.equals("병원")) {
+
+            return hospitalMenuRepository.findDistinctHospitalMenuKinds();
+
+
+        } else {
+            return null; //TODO: 학교,학교명인경우 추가
+        }
+    }
+}

--- a/src/main/java/devping/nnplanner/domain/monthmenu/controller/MonthMenuController.java
+++ b/src/main/java/devping/nnplanner/domain/monthmenu/controller/MonthMenuController.java
@@ -34,7 +34,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
-@RequestMapping("/api/monthmenus")
+@RequestMapping("/api/month-menus")
 @RestController
 @RequiredArgsConstructor
 public class MonthMenuController {

--- a/src/main/java/devping/nnplanner/domain/monthmenu/repository/MonthMenuRepository.java
+++ b/src/main/java/devping/nnplanner/domain/monthmenu/repository/MonthMenuRepository.java
@@ -1,5 +1,6 @@
 package devping.nnplanner.domain.monthmenu.repository;
 
+import devping.nnplanner.domain.menucategory.entity.MenuCategory;
 import devping.nnplanner.domain.monthmenu.entity.MonthMenu;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
@@ -11,4 +12,8 @@ public interface MonthMenuRepository extends JpaRepository<MonthMenu, UUID> {
     Page<MonthMenu> findAllByUser_UserId(Long userId, Pageable pageable);
 
     Integer countByUser_UserId(Long userId);
+
+    Page<MonthMenu> findAllByUser_UserIdAndMenuCategory(Long userId,
+                                                        MenuCategory menuCategory,
+                                                        Pageable pageable);
 }

--- a/src/main/java/devping/nnplanner/domain/openapi/controller/OpenApiController.java
+++ b/src/main/java/devping/nnplanner/domain/openapi/controller/OpenApiController.java
@@ -3,6 +3,7 @@ package devping.nnplanner.domain.openapi.controller;
 import devping.nnplanner.domain.openapi.service.SchoolInfoService;
 import devping.nnplanner.global.response.ApiResponse;
 import devping.nnplanner.global.response.GlobalResponse;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.Job;
@@ -30,7 +31,7 @@ public class OpenApiController {
     public ResponseEntity<ApiResponse<Void>> startFoodBatch() {
         try {
             JobParameters jobParameters = new JobParametersBuilder()
-                .addLong("timestamp", System.currentTimeMillis())
+                .addString("uniqueId", UUID.randomUUID().toString())
                 .toJobParameters();
 
             jobLauncher.run(importFoodDataJob, jobParameters);
@@ -57,7 +58,7 @@ public class OpenApiController {
     public ResponseEntity<ApiResponse<Void>> getHospitalMenu() {
         try {
             JobParameters jobParameters = new JobParametersBuilder()
-                .addLong("timestamp", System.currentTimeMillis())
+                .addString("uniqueId", UUID.randomUUID().toString())
                 .toJobParameters();
 
             jobLauncher.run(importHospitalMenuJob, jobParameters);

--- a/src/main/java/devping/nnplanner/domain/openapi/repository/HospitalMenuRepositoryCustom.java
+++ b/src/main/java/devping/nnplanner/domain/openapi/repository/HospitalMenuRepositoryCustom.java
@@ -6,4 +6,6 @@ import java.util.List;
 public interface HospitalMenuRepositoryCustom {
 
     List<HospitalMenu> findRandomHospitalMenusByCategory(String hospitalMenuKind, int dayCount);
+
+    List<String> findDistinctHospitalMenuKinds();
 }

--- a/src/main/java/devping/nnplanner/domain/openapi/repository/HospitalMenuRepositoryCustomImpl.java
+++ b/src/main/java/devping/nnplanner/domain/openapi/repository/HospitalMenuRepositoryCustomImpl.java
@@ -27,4 +27,13 @@ public class HospitalMenuRepositoryCustomImpl implements HospitalMenuRepositoryC
             .limit(dayCount)
             .fetch();
     }
+
+    public List<String> findDistinctHospitalMenuKinds() {
+        QHospitalMenu hospitalMenu = QHospitalMenu.hospitalMenu;
+
+        return queryFactory.select(hospitalMenu.hospitalMenuKind)
+                           .distinct()
+                           .from(hospitalMenu)
+                           .fetch();
+    }
 }

--- a/src/main/java/devping/nnplanner/global/config/WebSecurityConfig.java
+++ b/src/main/java/devping/nnplanner/global/config/WebSecurityConfig.java
@@ -53,13 +53,15 @@ public class WebSecurityConfig {
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers( // 인증o
-                    "api/auths/logout")
+                    "/api/auths/logout")
                 .authenticated()
                 .requestMatchers( // 인증x
-                    "api/auths/**",
-                    "api/openapis/**",
+                    "/api/auths/**",
+                    "/api/openapis/**",
+                    "/api/menu-categories",
                     "/actuator/health",
-                    "/"
+                    "/",
+                    "/error"
                 ).permitAll()
                 .anyRequest().authenticated())
             .formLogin(AbstractAuthenticationFilterConfigurer::disable)


### PR DESCRIPTION
### 주요사항
1. 소분류 카테고리 목록 조회 api 구현했습니다.
2. major-category 파라미터로 같이 요청보내면 소분류 목록이 응답됩니다.
3. 서버에서 배치 파라미터가 정상적으로 동작하지 않아서 파라미터 변수를 UUID 로 변경했습니다.