### PR TITLE
feature: 식단 검색 기능 구현

### DIFF
--- a/src/main/java/devping/nnplanner/domain/menucategory/controller/MenuCategoryController.java
+++ b/src/main/java/devping/nnplanner/domain/menucategory/controller/MenuCategoryController.java
@@ -1,17 +1,11 @@
 package devping.nnplanner.domain.menucategory.controller;
 
 import devping.nnplanner.domain.menucategory.service.MenuCategoryService;
-import devping.nnplanner.domain.monthmenu.dto.response.MonthMenuPageResponseDTO;
-import devping.nnplanner.global.jwt.user.UserDetailsImpl;
 import devping.nnplanner.global.response.ApiResponse;
 import devping.nnplanner.global.response.GlobalResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -31,23 +25,5 @@ public class MenuCategoryController {
         List<String> menuCategory = menuCategoryService.getMenuCategory(majorCategory);
 
         return GlobalResponse.OK("소분류 목록 조회 성공", menuCategory);
-    }
-
-    @GetMapping("/month-menus")
-    public ResponseEntity<ApiResponse<MonthMenuPageResponseDTO>> getAllMonthMenuByCategoryId(
-        @RequestParam("major-category") String majorCategory,
-        @RequestParam("minor-category") String minorCategory,
-        @AuthenticationPrincipal UserDetailsImpl userDetails,
-        @PageableDefault(page = 0, size = 8, sort = "createdAt",
-            direction = Sort.Direction.DESC) Pageable pageable) {
-
-        MonthMenuPageResponseDTO monthMenuPageResponseDTO =
-            menuCategoryService.getAllMonthMenuByCategoryId(
-                userDetails,
-                majorCategory,
-                minorCategory,
-                pageable);
-
-        return GlobalResponse.OK("작성한 식단 카테고리별 전체 조회 성공", monthMenuPageResponseDTO);
     }
 }

--- a/src/main/java/devping/nnplanner/domain/menucategory/service/MenuCategoryService.java
+++ b/src/main/java/devping/nnplanner/domain/menucategory/service/MenuCategoryService.java
@@ -1,19 +1,10 @@
 package devping.nnplanner.domain.menucategory.service;
 
-import devping.nnplanner.domain.menucategory.entity.MenuCategory;
 import devping.nnplanner.domain.menucategory.repository.MenuCategoryRepository;
-import devping.nnplanner.domain.monthmenu.dto.response.MonthMenuPageResponseDTO;
-import devping.nnplanner.domain.monthmenu.dto.response.MonthMenuResponseDTO;
-import devping.nnplanner.domain.monthmenu.entity.MonthMenu;
 import devping.nnplanner.domain.monthmenu.repository.MonthMenuRepository;
 import devping.nnplanner.domain.openapi.repository.HospitalMenuRepository;
-import devping.nnplanner.global.exception.CustomException;
-import devping.nnplanner.global.exception.ErrorCode;
-import devping.nnplanner.global.jwt.user.UserDetailsImpl;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,33 +27,5 @@ public class MenuCategoryService {
         } else {
             return null; //TODO: 학교,학교명인경우 추가
         }
-    }
-
-    @Transactional(readOnly = true)
-    public MonthMenuPageResponseDTO getAllMonthMenuByCategoryId(UserDetailsImpl userDetails,
-                                                                String majorCategory,
-                                                                String minorCategory,
-                                                                Pageable pageable) {
-
-        MenuCategory menuCategory =
-            menuCategoryRepository.findByMajorCategoryAndMinorCategory(majorCategory, minorCategory)
-                                  .orElseThrow(() -> new CustomException((ErrorCode.NOT_FOUND)));
-
-        Page<MonthMenu> monthMenuPage =
-            monthMenuRepository.findAllByUser_UserIdAndMenuCategory(
-                userDetails.getUser().getUserId(), menuCategory, pageable);
-
-        List<MonthMenuResponseDTO> menuResponseDTOS =
-            monthMenuPage.stream()
-                         .map(page -> new MonthMenuResponseDTO(page, null))
-                         .toList();
-
-        return new MonthMenuPageResponseDTO(
-            monthMenuPage.getNumber(),
-            monthMenuPage.getTotalPages(),
-            monthMenuPage.getTotalElements(),
-            monthMenuPage.getSize(),
-            menuResponseDTOS
-        );
     }
 }

--- a/src/main/java/devping/nnplanner/domain/monthmenu/dto/request/MonthCountRequestDTO.java
+++ b/src/main/java/devping/nnplanner/domain/monthmenu/dto/request/MonthCountRequestDTO.java
@@ -1,0 +1,22 @@
+package devping.nnplanner.domain.monthmenu.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class MonthCountRequestDTO {
+
+    private Integer totalMenuCount;
+
+    private Integer currentMenuCount;
+
+    private Integer lastMenuCount;
+
+    public MonthCountRequestDTO(Integer totalMenuCount,
+                                Integer currentMenuCount,
+                                Integer lastMenuCount) {
+
+        this.totalMenuCount = totalMenuCount;
+        this.currentMenuCount = currentMenuCount;
+        this.lastMenuCount = lastMenuCount;
+    }
+}

--- a/src/main/java/devping/nnplanner/domain/monthmenu/repository/MonthMenuRepository.java
+++ b/src/main/java/devping/nnplanner/domain/monthmenu/repository/MonthMenuRepository.java
@@ -2,12 +2,14 @@ package devping.nnplanner.domain.monthmenu.repository;
 
 import devping.nnplanner.domain.menucategory.entity.MenuCategory;
 import devping.nnplanner.domain.monthmenu.entity.MonthMenu;
+import java.time.LocalDateTime;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MonthMenuRepository extends JpaRepository<MonthMenu, UUID> {
+public interface MonthMenuRepository extends JpaRepository<MonthMenu, UUID>,
+    MonthMenuRepositoryCustom {
 
     Page<MonthMenu> findAllByUser_UserId(Long userId, Pageable pageable);
 
@@ -16,4 +18,8 @@ public interface MonthMenuRepository extends JpaRepository<MonthMenu, UUID> {
     Page<MonthMenu> findAllByUser_UserIdAndMenuCategory(Long userId,
                                                         MenuCategory menuCategory,
                                                         Pageable pageable);
+
+    Integer countByUser_UserIdAndCreatedAtBetween(Long userId,
+                                                  LocalDateTime startOfCurrentMonth,
+                                                  LocalDateTime endOfCurrentMonth);
 }

--- a/src/main/java/devping/nnplanner/domain/monthmenu/repository/MonthMenuRepositoryCustom.java
+++ b/src/main/java/devping/nnplanner/domain/monthmenu/repository/MonthMenuRepositoryCustom.java
@@ -1,0 +1,16 @@
+package devping.nnplanner.domain.monthmenu.repository;
+
+import devping.nnplanner.domain.monthmenu.entity.MonthMenu;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface MonthMenuRepositoryCustom {
+
+    Page<MonthMenu> searchByMenuNameOrDateAndCategory(Long userId,
+                                                      String majorCategory,
+                                                      String minorCategory,
+                                                      String menuName,
+                                                      Integer year,
+                                                      Integer month,
+                                                      Pageable pageable);
+}

--- a/src/main/java/devping/nnplanner/domain/monthmenu/repository/MonthMenuRepositoryCustomImpl.java
+++ b/src/main/java/devping/nnplanner/domain/monthmenu/repository/MonthMenuRepositoryCustomImpl.java
@@ -1,0 +1,94 @@
+package devping.nnplanner.domain.monthmenu.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import devping.nnplanner.domain.menucategory.entity.QMenuCategory;
+import devping.nnplanner.domain.monthmenu.entity.MonthMenu;
+import devping.nnplanner.domain.monthmenu.entity.QMonthMenu;
+import devping.nnplanner.domain.monthmenu.entity.QMonthMenuHospital;
+import devping.nnplanner.domain.monthmenu.entity.QMonthMenuSchool;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+@RequiredArgsConstructor
+public class MonthMenuRepositoryCustomImpl implements MonthMenuRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<MonthMenu> searchByMenuNameOrDateAndCategory(Long userId,
+                                                             String majorCategory,
+                                                             String minorCategory,
+                                                             String menuName,
+                                                             Integer year,
+                                                             Integer month,
+                                                             Pageable pageable) {
+
+        QMonthMenu monthMenu = QMonthMenu.monthMenu;
+        QMenuCategory menuCategory = QMenuCategory.menuCategory;
+        QMonthMenuHospital monthMenuHospital = QMonthMenuHospital.monthMenuHospital;
+        QMonthMenuSchool monthMenuSchool = QMonthMenuSchool.monthMenuSchool;
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        // 사용자 ID로 필터링
+        builder.and(monthMenu.user.userId.eq(userId));
+
+        // 카테고리로 필터링 (majorCategory, minorCategory)
+        if (majorCategory != null && minorCategory != null) {
+            builder.and(monthMenu.menuCategory.majorCategory.eq(majorCategory)
+                                                            .and(
+                                                                monthMenu.menuCategory.minorCategory.eq(
+                                                                    minorCategory)));
+        }
+
+        // 메뉴 이름으로 필터링
+        if (menuName != null) {
+            builder.and(monthMenu.monthMenuName.containsIgnoreCase(menuName));
+        }
+
+        // 날짜로 필터링 (연도와 월, 병원 및 학교 관계 테이블을 고려)
+        if (year != null && month != null) {
+            BooleanBuilder dateBuilder = new BooleanBuilder();
+
+            dateBuilder.or(monthMenuHospital.menuDate.year().eq(year)
+                                                     .and(monthMenuHospital.menuDate.month()
+                                                                                    .eq(month)));
+            dateBuilder.or(monthMenuSchool.menuDate.year().eq(year)
+                                                   .and(
+                                                       monthMenuSchool.menuDate.month().eq(month)));
+
+            builder.and(dateBuilder);
+        }
+
+        // 페이지 데이터 조회
+        List<MonthMenu> content = queryFactory
+            .selectFrom(monthMenu)
+            .leftJoin(monthMenu.menuCategory, menuCategory)
+            .leftJoin(monthMenuHospital).on(monthMenuHospital.monthMenu.eq(monthMenu))
+            .leftJoin(monthMenuSchool).on(monthMenuSchool.monthMenu.eq(monthMenu))
+            .where(builder)
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .orderBy(monthMenu.createdAt.desc())
+            .fetch();
+
+        // 총 개수 조회 (null 방지)
+        Long total = queryFactory
+            .select(monthMenu.count())
+            .from(monthMenu)
+            .leftJoin(monthMenu.menuCategory, menuCategory)
+            .leftJoin(monthMenuHospital).on(monthMenuHospital.monthMenu.eq(monthMenu))
+            .leftJoin(monthMenuSchool).on(monthMenuSchool.monthMenu.eq(monthMenu))
+            .where(builder)
+            .fetchOne();
+
+        // total 값이 null인 경우 0으로 처리
+        long totalElements = (total != null) ? total : 0L;
+
+        return new PageImpl<>(content, pageable, totalElements);
+    }
+}


### PR DESCRIPTION
### 주요사항
1. 카테고리, 식단 이름, 월별로 검색할 수 있는 api 를 구현했습니다.
2. 각각 개별로 검색도 가능하고 조합하여 검색도 가능합니다. 값은 파라미터로 보내주시면 됩니다.
3. 조회는 QueryDSL 을 사용하여 구현하였습니다.
4. 식단 카운트 api 비즈니스 로직과 응답값을 수정했습니다.
5. 내가 작성한 식단 총갯수, 이번달에 작성한 식단 갯수, 지난달에 작성한 식단 갯수를 응답합니다.